### PR TITLE
triangle → sine wave

### DIFF
--- a/Xcode Project/Pitch/SoundGenerator.swift
+++ b/Xcode Project/Pitch/SoundGenerator.swift
@@ -24,7 +24,7 @@ class SoundGenerator : NSObject {
     // MARK: - Setup
     
     override init() {
-        bank = AKOscillatorBank(waveform: AKTable(.triangle), attackDuration: 0.06, releaseDuration: 0.06)
+        bank = AKOscillatorBank(waveform: AKTable(.sine), attackDuration: 0.06, releaseDuration: 0.06)
         super.init()
         
         setPitchStandard()


### PR DESCRIPTION
Sine waves are the purest tones (cf. Helmholtz's [_On the Sensations of Tone_](https://isidore.co/calibre/browse/book/4884)), so they should be used instead of triangle waves.